### PR TITLE
Changed travis to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: php
 
 sudo: false
 
+dist: trusty
+
 php:
     - 5.5
     - 5.6


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC break      | no
| Tests passed? | yes
| Fixed tickets | n/a
| License       | MIT

HHVM is only supported on Trusty
